### PR TITLE
Add configurable language options and config page

### DIFF
--- a/backend/recentchanges/templates/recentchanges/config.html
+++ b/backend/recentchanges/templates/recentchanges/config.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wikipedia Configuration</title>
+    <style>
+      :root {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f3f4f6;
+        color: #111827;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      .top-bar {
+        background: white;
+        border-bottom: 1px solid #e5e7eb;
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .brand {
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 3rem;
+      }
+
+      form {
+        background: white;
+        padding: 1.5rem;
+        border-radius: 0.75rem;
+        box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      label {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      select,
+      input[type='number'] {
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        border-radius: 0.5rem;
+        border: 1px solid #d1d5db;
+        background: white;
+      }
+
+      button {
+        padding: 0.75rem 1.25rem;
+        font-size: 1rem;
+        border-radius: 0.5rem;
+        border: none;
+        background: #2563eb;
+        color: white;
+        cursor: pointer;
+        justify-self: start;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+
+      .status {
+        font-size: 0.95rem;
+        color: #059669;
+      }
+
+      .hint {
+        font-size: 0.9rem;
+        color: #6b7280;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="brand">Wikipedia Preferences</div>
+      <div class="nav-actions">
+        <a href="{{ home_url }}">Home</a>
+        <a href="{{ config_url }}" aria-current="page">Config</a>
+      </div>
+    </header>
+    <main>
+      <h1>Edit Wikipedia Options</h1>
+      <p class="hint">
+        Adjust how many edits you see by default and which Wikipedia language the app opens.
+        Your settings are saved in your browser.
+      </p>
+      <form id="config-form">
+        <label>
+          Default language
+          <select id="language"></select>
+        </label>
+        <label>
+          Maximum edits to fetch
+          <input type="number" id="limit" min="{{ min_edit_limit }}" max="{{ max_edit_limit }}" step="1" />
+          <span class="hint">Between {{ min_edit_limit }} and {{ max_edit_limit }} edits.</span>
+        </label>
+        <button type="submit">Save preferences</button>
+        <p class="status" id="status" role="status" aria-live="polite"></p>
+      </form>
+    </main>
+
+    <script>
+      const supportedLanguages = JSON.parse('{{ supported_languages_json|escapejs }}');
+      const defaultLanguage = '{{ default_language|escapejs }}';
+      const defaultEditLimit = Number('{{ default_edit_limit|escapejs }}') || 50;
+      const minEditLimit = Number('{{ min_edit_limit|escapejs }}') || 1;
+      const maxEditLimit = Number('{{ max_edit_limit|escapejs }}') || 200;
+      const storageKey = 'recentChangesPreferences';
+
+      const clampLimit = (value) => {
+        const parsed = Number.parseInt(value ?? defaultEditLimit, 10);
+        if (!Number.isFinite(parsed)) {
+          return defaultEditLimit;
+        }
+        return Math.min(maxEditLimit, Math.max(minEditLimit, parsed));
+      };
+
+      const loadPreferences = () => {
+        try {
+          const raw = localStorage.getItem(storageKey);
+          if (!raw) {
+            return {};
+          }
+          const parsed = JSON.parse(raw);
+          if (!parsed || typeof parsed !== 'object') {
+            return {};
+          }
+          return parsed;
+        } catch (error) {
+          console.warn('Failed to load preferences:', error);
+          return {};
+        }
+      };
+
+      const persistPreferences = (preferences) => {
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(preferences));
+        } catch (error) {
+          console.warn('Failed to save preferences:', error);
+        }
+      };
+
+      const languageSelect = document.getElementById('language');
+      const limitInput = document.getElementById('limit');
+      const statusElement = document.getElementById('status');
+
+      const renderLanguages = () => {
+        languageSelect.innerHTML = '';
+        supportedLanguages.forEach((lang) => {
+          const option = document.createElement('option');
+          option.value = lang;
+          option.textContent = lang.toUpperCase();
+          languageSelect.appendChild(option);
+        });
+      };
+
+      const populateForm = () => {
+        const preferences = loadPreferences();
+        const selectedLanguage =
+          preferences.language && supportedLanguages.includes(preferences.language)
+            ? preferences.language
+            : defaultLanguage;
+        const limit = clampLimit(preferences.limit);
+        languageSelect.value = selectedLanguage;
+        limitInput.value = limit;
+      };
+
+      renderLanguages();
+      populateForm();
+
+      document.getElementById('config-form').addEventListener('submit', (event) => {
+        event.preventDefault();
+        const selectedLanguage = languageSelect.value;
+        const limit = clampLimit(limitInput.value);
+        limitInput.value = limit;
+        const preferences = {
+          language: supportedLanguages.includes(selectedLanguage)
+            ? selectedLanguage
+            : defaultLanguage,
+          limit,
+        };
+        persistPreferences(preferences);
+        statusElement.textContent = 'Preferences saved successfully!';
+        setTimeout(() => {
+          statusElement.textContent = '';
+        }, 3000);
+      });
+    </script>
+  </body>
+</html>

--- a/backend/recentchanges/templates/recentchanges/index.html
+++ b/backend/recentchanges/templates/recentchanges/index.html
@@ -16,15 +16,35 @@
         padding: 0;
       }
 
+      .top-bar {
+        background: white;
+        border-bottom: 1px solid #e5e7eb;
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+
+      .brand {
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
       main {
         max-width: 960px;
         margin: 0 auto;
-        padding: 2rem 1.5rem 4rem;
-      }
-
-      h1 {
-        text-align: center;
-        margin-bottom: 1.5rem;
+        padding: 2.5rem 1.5rem 4rem;
       }
 
       .controls {
@@ -100,9 +120,9 @@
   <body>
     {% verbatim %}
     <div id="app">
-      <main>
-        <h1>Wikipedia Recent Edits</h1>
-        <section class="controls">
+      <header class="top-bar">
+        <div class="brand">Wikipedia Recent Edits</div>
+        <div class="nav-actions">
           <label>
             Language
             <select v-model="selectedLanguage" @change="fetchEdits">
@@ -111,9 +131,15 @@
               </option>
             </select>
           </label>
+          <a :href="configUrl">Config</a>
+        </div>
+      </header>
+      <main>
+        <section class="controls">
           <button type="button" @click="fetchEdits" :disabled="loading">
             {{ loading ? 'Loading…' : 'Refresh' }}
           </button>
+          <p class="meta">Showing up to {{ limit }} recent edits.</p>
         </section>
 
         <p class="error" v-if="error">{{ error }}</p>
@@ -145,33 +171,104 @@
       const supportedLanguages = JSON.parse('{{ supported_languages_json|escapejs }}');
       const defaultLanguage = '{{ default_language|escapejs }}';
       const apiUrl = '{{ api_url|escapejs }}';
+      const configUrl = '{{ config_url|escapejs }}';
+      const defaultEditLimit = Number('{{ default_edit_limit|escapejs }}') || 50;
+      const minEditLimit = Number('{{ min_edit_limit|escapejs }}') || 1;
+      const maxEditLimit = Number('{{ max_edit_limit|escapejs }}') || 200;
+
+      const storageKey = 'recentChangesPreferences';
+
+      const clampLimit = (value) => {
+        const parsed = Number.parseInt(value ?? defaultEditLimit, 10);
+        if (!Number.isFinite(parsed)) {
+          return defaultEditLimit;
+        }
+        return Math.min(maxEditLimit, Math.max(minEditLimit, parsed));
+      };
+
+      const loadPreferences = () => {
+        try {
+          const raw = localStorage.getItem(storageKey);
+          if (!raw) {
+            return {};
+          }
+          const parsed = JSON.parse(raw);
+          if (!parsed || typeof parsed !== 'object') {
+            return {};
+          }
+          return parsed;
+        } catch (error) {
+          console.warn('Failed to load preferences:', error);
+          return {};
+        }
+      };
+
+      const savePreferencesToStorage = (preferences) => {
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(preferences));
+        } catch (error) {
+          console.warn('Failed to save preferences:', error);
+        }
+      };
 
       const { createApp } = Vue;
 
       createApp({
         data() {
+          const savedPreferences = loadPreferences();
+          const initialLanguage =
+            savedPreferences.language && supportedLanguages.includes(savedPreferences.language)
+              ? savedPreferences.language
+              : defaultLanguage;
+          const initialLimit = clampLimit(savedPreferences.limit);
           return {
             languages: supportedLanguages,
-            selectedLanguage: defaultLanguage,
+            selectedLanguage: initialLanguage,
+            limit: initialLimit,
             edits: [],
             error: '',
             loading: false,
+            configUrl,
           };
         },
         mounted() {
+          this.savePreferences();
           this.fetchEdits();
         },
+        watch: {
+          selectedLanguage(newLanguage) {
+            if (!this.languages.includes(newLanguage)) {
+              return;
+            }
+            this.savePreferences();
+          },
+        },
         methods: {
+          savePreferences() {
+            const preferences = {
+              language: this.selectedLanguage,
+              limit: clampLimit(this.limit),
+            };
+            savePreferencesToStorage(preferences);
+          },
           async fetchEdits() {
             this.loading = true;
             this.error = '';
             try {
-              const response = await fetch(`${apiUrl}?lang=${this.selectedLanguage}`);
+              const params = new URLSearchParams({
+                lang: this.selectedLanguage,
+                limit: String(clampLimit(this.limit)),
+              });
+              const response = await fetch(`${apiUrl}?${params.toString()}`);
               if (!response.ok) {
                 throw new Error(`Failed to load data (status ${response.status})`);
               }
               const payload = await response.json();
               this.edits = payload.edits || [];
+              if (typeof payload.limit === 'number') {
+                this.limit = clampLimit(payload.limit);
+                this.savePreferences();
+              }
             } catch (error) {
               this.error = error.message || 'Failed to load data.';
               this.edits = [];

--- a/backend/recentchanges/urls.py
+++ b/backend/recentchanges/urls.py
@@ -1,11 +1,12 @@
 """URL patterns for the recentchanges app."""
 from django.urls import path
 
-from .views import RecentEditsPageView, RecentEditsView
+from .views import ConfigPageView, RecentEditsPageView, RecentEditsView
 
 app_name = 'recentchanges'
 
 urlpatterns = [
     path('', RecentEditsPageView.as_view(), name='recent_edits_page'),
+    path('config/', ConfigPageView.as_view(), name='config_page'),
     path('api/recent-edits/', RecentEditsView.as_view(), name='recent_edits'),
 ]


### PR DESCRIPTION
## Summary
- add Hungarian and Polish Wikipedia options and surface the language selector in a persistent top navigation bar
- introduce a configuration page that lets users store their preferred language and edit limit in the browser
- allow the recent edits API to accept a configurable limit with validation and expand automated tests accordingly

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d632c2fe44832ead19d643b8ba4a88