### PR TITLE
Fix dataclass decorator for Python 3.9 compatibility

### DIFF
--- a/backend/reviews/services.py
+++ b/backend/reviews/services.py
@@ -21,7 +21,7 @@ os.environ.setdefault("PYWIKIBOT2_NO_USER_CONFIG", "1")
 os.environ.setdefault("PYWIKIBOT_NO_USER_CONFIG", "2")
 
 
-@dataclass(slots=True)
+@dataclass
 class RevisionPayload:
     revid: int
     parentid: int | None


### PR DESCRIPTION
## Summary
- remove the use of the dataclass ``slots`` parameter so the project works on Python versions that do not support it

## Testing
- python manage.py makemigrations

------
https://chatgpt.com/codex/tasks/task_e_68deedadb8d0832e8e99f40c0cd154d9