### PR TITLE
Use public Pywikibot simple_request API

### DIFF
--- a/backend/reviews/services.py
+++ b/backend/reviews/services.py
@@ -44,7 +44,7 @@ class WikiClient:
     def fetch_pending_pages(self, limit: int = 50) -> list[PendingPage]:
         """Fetch the oldest pending pages and cache them in the database."""
 
-        request = self.site._simple_request(
+        request = self.site.simple_request(
             action="query",
             format="json",
             list="oldreviewedpages",
@@ -78,7 +78,7 @@ class WikiClient:
     def fetch_revisions_for_page(self, page: PendingPage) -> list[PendingRevision]:
         """Fetch pending revisions for a single page using Pywikibot."""
 
-        request = self.site._simple_request(
+        request = self.site.simple_request(
             action="query",
             pageids=str(page.pageid),
             prop="revisions",

--- a/backend/reviews/tests/test_services.py
+++ b/backend/reviews/tests/test_services.py
@@ -23,7 +23,7 @@ class FakeSite:
         self.users_data: dict[str, dict] = {}
         self.requests: list[dict] = []
 
-    def _simple_request(self, **kwargs):
+    def simple_request(self, **kwargs):
         self.requests.append(kwargs)
         return FakeRequest(self.response)
 
@@ -179,7 +179,7 @@ class RefreshWorkflowTests(TestCase):
         fake_site = FakeSite()
         fake_site.response = {"query": {"pages": []}}
         mock_site.return_value = fake_site
-        fake_site._simple_request = mock.Mock(side_effect=RuntimeError("boom"))
+        fake_site.simple_request = mock.Mock(side_effect=RuntimeError("boom"))
         client = WikiClient(wiki)
         with self.assertRaises(RuntimeError):
             client.refresh()


### PR DESCRIPTION
## Summary
- update the wiki client to call pywikibot's public `simple_request` helper
- adjust service tests to use the new method name when faking requests

## Testing
- python manage.py test reviews.tests.test_services

------
https://chatgpt.com/codex/tasks/task_e_68deefdbb050832e963b1c25d5895e89