### PR TITLE
Add toggle for configuration panel

### DIFF
--- a/backend/static/reviews/app.js
+++ b/backend/static/reviews/app.js
@@ -29,6 +29,7 @@ createApp({
       pages: [],
       loading: false,
       error: "",
+      configurationOpen: true,
     });
 
     const forms = reactive({
@@ -149,9 +150,14 @@ createApp({
       return formatDateTime(value);
     }
 
+    function toggleConfiguration() {
+      state.configurationOpen = !state.configurationOpen;
+    }
+
     watch(currentWiki, () => {
       syncForms();
       loadPending();
+      state.configurationOpen = true;
     }, { immediate: true });
 
     onMounted(() => {
@@ -167,6 +173,7 @@ createApp({
       saveConfiguration,
       loadPending,
       formatDate,
+      toggleConfiguration,
     };
   },
 }).mount("#app");

--- a/backend/templates/reviews/index.html
+++ b/backend/templates/reviews/index.html
@@ -42,19 +42,34 @@
 
       <section class="section" v-if="currentWiki">
         <div class="box mb-5">
-          <h2 class="title is-4">Configuration</h2>
-          <div class="columns">
-            <div class="column">
-              <label class="label">Blocking categories</label>
-              <textarea class="textarea" rows="4" v-model="forms.blockingCategories" placeholder="One category per line"></textarea>
+          <div class="level is-mobile">
+            <div class="level-left">
+              <div class="level-item">
+                <h2 class="title is-4 mb-0">Configuration</h2>
+              </div>
             </div>
-            <div class="column">
-              <label class="label">Auto-approved user groups</label>
-              <textarea class="textarea" rows="4" v-model="forms.autoApprovedGroups" placeholder="One user group per line"></textarea>
+            <div class="level-right">
+              <div class="level-item">
+                <button class="button is-small is-text" @click="toggleConfiguration">
+                  {{ state.configurationOpen ? 'Hide' : 'Show' }}
+                </button>
+              </div>
             </div>
           </div>
-          <div class="buttons">
-            <button class="button is-primary" @click="saveConfiguration">Save configuration</button>
+          <div v-show="state.configurationOpen">
+            <div class="columns">
+              <div class="column">
+                <label class="label">Blocking categories</label>
+                <textarea class="textarea" rows="4" v-model="forms.blockingCategories" placeholder="One category per line"></textarea>
+              </div>
+              <div class="column">
+                <label class="label">Auto-approved user groups</label>
+                <textarea class="textarea" rows="4" v-model="forms.autoApprovedGroups" placeholder="One user group per line"></textarea>
+              </div>
+            </div>
+            <div class="buttons">
+              <button class="button is-primary" @click="saveConfiguration">Save configuration</button>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add UI state to control the visibility of the configuration form
- provide a button to toggle the configuration section open or closed
- reset the configuration panel to open when switching between wikis

## Testing
- pytest *(fails: settings module not configured for standalone test execution)*
- python manage.py migrate --noinput

------
https://chatgpt.com/codex/tasks/task_e_68def14bc988832e89121eb914ab56ec