### PR TITLE
Persist settings panel open state

### DIFF
--- a/backend/static/reviews/app.js
+++ b/backend/static/reviews/app.js
@@ -23,13 +23,40 @@ createApp({
     const initialElement = document.getElementById("initial-wikis");
     const initialData = initialElement ? JSON.parse(initialElement.textContent) : [];
 
+    const configurationStorageKey = "configurationOpen";
+
+    function loadConfigurationOpen() {
+      if (typeof window === "undefined") {
+        return false;
+      }
+      try {
+        return window.localStorage.getItem(configurationStorageKey) === "true";
+      } catch (error) {
+        return false;
+      }
+    }
+
+    function persistConfigurationOpen(value) {
+      if (typeof window === "undefined") {
+        return;
+      }
+      try {
+        window.localStorage.setItem(
+          configurationStorageKey,
+          value ? "true" : "false",
+        );
+      } catch (error) {
+        // Ignore storage errors.
+      }
+    }
+
     const state = reactive({
       wikis: initialData,
       selectedWikiId: initialData.length ? initialData[0].id : "",
       pages: [],
       loading: false,
       error: "",
-      configurationOpen: true,
+      configurationOpen: loadConfigurationOpen(),
     });
 
     const forms = reactive({
@@ -154,10 +181,17 @@ createApp({
       state.configurationOpen = !state.configurationOpen;
     }
 
+    watch(
+      () => state.configurationOpen,
+      (newValue) => {
+        persistConfigurationOpen(newValue);
+      },
+      { immediate: true },
+    );
+
     watch(currentWiki, () => {
       syncForms();
       loadPending();
-      state.configurationOpen = true;
     }, { immediate: true });
 
     onMounted(() => {


### PR DESCRIPTION
## Summary
- persist the configuration panel's open state across sessions using localStorage
- default the panel to closed when no stored preference exists and stop forcing it open when switching wikis

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68def4b7031c832eafbacfd342687cac