### PR TITLE
Load revision data when fetching pending pages

### DIFF
--- a/backend/reviews/urls.py
+++ b/backend/reviews/urls.py
@@ -7,6 +7,11 @@ urlpatterns = [
     path("api/wikis/", views.api_wikis, name="api_wikis"),
     path("api/wikis/<int:pk>/refresh/", views.api_refresh, name="api_refresh"),
     path("api/wikis/<int:pk>/pending/", views.api_pending, name="api_pending"),
+    path(
+        "api/wikis/<int:pk>/pages/<int:pageid>/revisions/",
+        views.api_page_revisions,
+        name="api_page_revisions",
+    ),
     path("api/wikis/<int:pk>/clear/", views.api_clear_cache, name="api_clear_cache"),
     path("api/wikis/<int:pk>/configuration/", views.api_configuration, name="api_configuration"),
 ]


### PR DESCRIPTION
## Summary
- add a reusable serializer for revision payloads and expose an endpoint for fetching revisions for a specific page
- update the Vue frontend to retrieve revision data after loading pending pages so the table is populated
- extend the view tests to cover the new revision endpoint

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68def5d65080832e84a709616c9e136a