### PR TITLE
Fix pending page revisions fallback

### DIFF
--- a/backend/static/reviews/app.js
+++ b/backend/static/reviews/app.js
@@ -121,7 +121,10 @@ createApp({
         const data = await apiRequest(`/api/wikis/${wikiId}/pending/`);
         const pagesWithRevisions = await Promise.all(
           (data.pages || []).map(async (page) => {
-            const revisions = await fetchRevisionsForPage(wikiId, page.pageid);
+            let revisions = Array.isArray(page.revisions) ? page.revisions : [];
+            if (!revisions.length) {
+              revisions = await fetchRevisionsForPage(wikiId, page.pageid);
+            }
             return {
               ...page,
               revisions,


### PR DESCRIPTION
## Summary
- keep the pending revisions returned by `/pending/` responses instead of blindly replacing them with a fresh fetch
- only fall back to the per-page revisions endpoint when the cached list is empty so single pending edits remain visible

## Testing
- `python backend/manage.py test reviews`


------
https://chatgpt.com/codex/tasks/task_e_68defa77ab5c832e8ca4093a4337ea29