### PR TITLE
Link pending page titles to latest wiki articles

### DIFF
--- a/backend/static/reviews/app.js
+++ b/backend/static/reviews/app.js
@@ -201,6 +201,31 @@ createApp({
       return formatDateTime(value);
     }
 
+    function formatTitle(title) {
+      if (!title) {
+        return "";
+      }
+      return title.replace(/_/g, " ");
+    }
+
+    function buildLatestRevisionUrl(page) {
+      if (!page || !page.title) {
+        return "";
+      }
+      const wiki = currentWiki.value;
+      if (!wiki || !wiki.api_endpoint) {
+        return "";
+      }
+      const normalizedTitle = page.title.replace(/ /g, "_");
+      const encodedTitle = encodeURIComponent(normalizedTitle);
+      try {
+        const apiUrl = new URL(wiki.api_endpoint);
+        return `${apiUrl.origin}/wiki/${encodedTitle}`;
+      } catch (error) {
+        return `/wiki/${encodedTitle}`;
+      }
+    }
+
     function toggleConfiguration() {
       state.configurationOpen = !state.configurationOpen;
     }
@@ -232,6 +257,8 @@ createApp({
       loadPending,
       formatDate,
       toggleConfiguration,
+      formatTitle,
+      buildLatestRevisionUrl,
     };
   },
 }).mount("#app");

--- a/backend/templates/reviews/index.html
+++ b/backend/templates/reviews/index.html
@@ -79,7 +79,16 @@
             <article v-for="page in state.pages" :key="page.pageid" class="card mb-5">
               <header class="card-header">
                 <p class="card-header-title is-size-5 is-flex is-align-items-center">
-                  <span>{{ page.title }}</span>
+                  <span>
+                    <a
+                      :href="buildLatestRevisionUrl(page)"
+                      class="has-text-link"
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      {{ formatTitle(page.title) }}
+                    </a>
+                  </span>
                   <span
                     class="is-size-6 has-text-grey ml-3"
                     v-if="page.pending_since"


### PR DESCRIPTION
## Summary
- display pending page titles with spaces instead of underscores
- link each pending page title to the latest article view on the associated wiki

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df0cbf7c34832ebaa13f571be076eb