### PR TITLE
Add default German, English, Polish, and Portuguese wikis

### DIFF
--- a/backend/reviews/tests/test_views.py
+++ b/backend/reviews/tests/test_views.py
@@ -25,7 +25,8 @@ class ViewTests(TestCase):
         response = self.client.get(reverse("index"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Pending Changes Review")
-        self.assertTrue(Wiki.objects.exists())
+        codes = list(Wiki.objects.values_list("code", flat=True))
+        self.assertCountEqual(codes, ["de", "en", "pl", "pt"])
 
     @mock.patch("reviews.views.WikiClient")
     def test_api_refresh_returns_error_on_failure(self, mock_client):

--- a/backend/reviews/views.py
+++ b/backend/reviews/views.py
@@ -20,13 +20,37 @@ def index(request: HttpRequest) -> HttpResponse:
 
     wikis = Wiki.objects.all().order_by("code")
     if not wikis.exists():
-        default_api = "https://fi.wikipedia.org/w/api.php"
-        wiki = Wiki.objects.create(
-            name="Finnish Wikipedia",
-            code="fi",
-            api_endpoint=default_api,
+        default_wikis = (
+            {
+                "name": "German Wikipedia",
+                "code": "de",
+                "api_endpoint": "https://de.wikipedia.org/w/api.php",
+            },
+            {
+                "name": "English Wikipedia",
+                "code": "en",
+                "api_endpoint": "https://en.wikipedia.org/w/api.php",
+            },
+            {
+                "name": "Polish Wikipedia",
+                "code": "pl",
+                "api_endpoint": "https://pl.wikipedia.org/w/api.php",
+            },
+            {
+                "name": "Portuguese Wikipedia",
+                "code": "pt",
+                "api_endpoint": "https://pt.wikipedia.org/w/api.php",
+            },
         )
-        WikiConfiguration.objects.get_or_create(wiki=wiki)
+        for defaults in default_wikis:
+            wiki, _ = Wiki.objects.get_or_create(
+                code=defaults["code"],
+                defaults={
+                    "name": defaults["name"],
+                    "api_endpoint": defaults["api_endpoint"],
+                },
+            )
+            WikiConfiguration.objects.get_or_create(wiki=wiki)
         wikis = Wiki.objects.all().order_by("code")
     payload = []
     for wiki in wikis:


### PR DESCRIPTION
## Summary
- seed the database with German, English, Polish, and Portuguese Wikipedia instances when no wikis exist
- update the index view test to assert the expected default wiki codes

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68df0e47b5ac832e82f191e4149f8a91