### PR TITLE
Add persistent pending page sorting controls

### DIFF
--- a/backend/templates/reviews/index.html
+++ b/backend/templates/reviews/index.html
@@ -35,6 +35,18 @@
                   <button class="button is-warning" @click="clearCache">Clear cache</button>
                 </div>
               </div>
+              <div class="field is-grouped is-align-items-center mt-3">
+                <label class="label mr-2 mb-0">Sort by</label>
+                <div class="control">
+                  <div class="select">
+                    <select v-model="state.sortOrder">
+                      <option value="newest">Newest pending page first</option>
+                      <option value="oldest">Oldest pending page first</option>
+                      <option value="random">Random order</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add client-side storage helpers to persist the selected wiki and sorting option
- allow pending pages to be sorted newest first, oldest first, or in random order
- apply the chosen ordering when loading pages so the list reflects the selection

## Testing
- pytest *(fails: Django settings module not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df12879d14832e8f4b7fb07942e2a9