### PR TITLE
Limit pending pages list to 10 entries

### DIFF
--- a/backend/static/reviews/app.js
+++ b/backend/static/reviews/app.js
@@ -26,6 +26,7 @@ createApp({
     const configurationStorageKey = "configurationOpen";
     const selectedWikiStorageKey = "selectedWikiId";
     const sortOrderStorageKey = "pendingSortOrder";
+    const pageDisplayLimit = 10;
 
     function loadFromStorage(key) {
       if (typeof window === "undefined") {
@@ -153,6 +154,10 @@ createApp({
     const currentWiki = computed(() =>
       state.wikis.find((wiki) => wiki.id === state.selectedWikiId) || null,
     );
+
+    const visiblePages = computed(() => state.pages.slice(0, pageDisplayLimit));
+
+    const hasMorePages = computed(() => state.pages.length > pageDisplayLimit);
 
     function syncForms() {
       if (!currentWiki.value) {
@@ -354,6 +359,9 @@ createApp({
       state,
       forms,
       currentWiki,
+      visiblePages,
+      hasMorePages,
+      pageDisplayLimit,
       refresh,
       clearCache,
       saveConfiguration,

--- a/backend/templates/reviews/index.html
+++ b/backend/templates/reviews/index.html
@@ -88,7 +88,10 @@
         <div v-if="state.pages.length">
           <div class="content">
             <h2 class="title is-4">Pending pages</h2>
-            <article v-for="page in state.pages" :key="page.pageid" class="card mb-5">
+            <p class="help" v-if="hasMorePages">
+              Showing the first {{ pageDisplayLimit }} of {{ state.pages.length }} pending pages.
+            </p>
+            <article v-for="page in visiblePages" :key="page.pageid" class="card mb-5">
               <header class="card-header">
                 <p class="card-header-title is-size-5 is-flex is-align-items-center">
                   <span>


### PR DESCRIPTION
## Summary
- limit the pending pages display to the first 10 items after sorting
- show a helper message when additional pending pages are hidden

## Testing
- pytest *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68df15dc0efc832eabb3f30915ba28a5