### PR TITLE
Translate autoreview messages to English

### DIFF
--- a/app/reviews/autoreview.py
+++ b/app/reviews/autoreview.py
@@ -1,0 +1,242 @@
+"""Logic for simulating automatic review decisions for pending revisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .models import EditorProfile, PendingPage, PendingRevision
+
+
+@dataclass(frozen=True)
+class AutoreviewDecision:
+    """Represents the aggregated outcome for a revision."""
+
+    status: str
+    label: str
+    reason: str
+
+
+def run_autoreview_for_page(page: PendingPage) -> list[dict]:
+    """Run the configured autoreview checks for each pending revision of a page."""
+
+    revisions = list(
+        page.revisions.all().order_by("timestamp", "revid")
+    )  # Oldest revision first.
+    usernames = {revision.user_name for revision in revisions if revision.user_name}
+    profiles = {
+        profile.username: profile
+        for profile in EditorProfile.objects.filter(
+            wiki=page.wiki, username__in=usernames
+        )
+    }
+    configuration = page.wiki.configuration
+
+    auto_groups = _normalize_to_lookup(configuration.auto_approved_groups)
+    blocking_categories = _normalize_to_lookup(configuration.blocking_categories)
+
+    results: list[dict] = []
+    for revision in revisions:
+        profile = profiles.get(revision.user_name or "")
+        revision_result = _evaluate_revision(
+            revision,
+            profile,
+            auto_groups=auto_groups,
+            blocking_categories=blocking_categories,
+        )
+        results.append(
+            {
+                "revid": revision.revid,
+                "tests": revision_result["tests"],
+                "decision": {
+                    "status": revision_result["decision"].status,
+                    "label": revision_result["decision"].label,
+                    "reason": revision_result["decision"].reason,
+                },
+            }
+        )
+
+    return results
+
+
+def _evaluate_revision(
+    revision: PendingRevision,
+    profile: EditorProfile | None,
+    *,
+    auto_groups: dict[str, str],
+    blocking_categories: dict[str, str],
+) -> dict:
+    tests: list[dict] = []
+
+    # Test 1: Bot editors can always be auto-approved.
+    if _is_bot_user(revision, profile):
+        tests.append(
+            {
+                "id": "bot-user",
+                "title": "Bot user",
+                "status": "passed",
+                "message": "The edit could be auto-approved because the user is a bot.",
+            }
+        )
+        return {
+            "tests": tests,
+            "decision": AutoreviewDecision(
+                status="approve",
+                label="Would be auto-approved",
+                reason="The user is recognized as a bot.",
+            ),
+        }
+
+    tests.append(
+        {
+            "id": "bot-user",
+            "title": "Bot user",
+            "status": "failed",
+            "message": "The user is not marked as a bot.",
+        }
+    )
+
+    # Test 2: Editors in the allow-list can be auto-approved.
+    matched_groups = _matched_user_groups(
+        revision, profile, allowed_groups=auto_groups
+    )
+    if matched_groups:
+        tests.append(
+            {
+                "id": "auto-approved-group",
+                "title": "Auto-approved groups",
+                "status": "passed",
+                "message": "The user belongs to groups: {}.".format(
+                    ", ".join(sorted(matched_groups))
+                ),
+            }
+        )
+        return {
+            "tests": tests,
+            "decision": AutoreviewDecision(
+                status="approve",
+                label="Would be auto-approved",
+                reason="The user belongs to groups that are auto-approved.",
+            ),
+        }
+
+    tests.append(
+        {
+            "id": "auto-approved-group",
+            "title": "Auto-approved groups",
+            "status": "failed",
+            "message": "The user does not belong to auto-approved groups.",
+        }
+    )
+
+    # Test 3: Blocking categories on the old version prevent automatic approval.
+    blocking_hits = _blocking_category_hits(revision, blocking_categories)
+    if blocking_hits:
+        tests.append(
+            {
+                "id": "blocking-categories",
+                "title": "Blocking categories",
+                "status": "failed",
+                "message": "The previous version belongs to blocking categories: {}.".format(
+                    ", ".join(sorted(blocking_hits))
+                ),
+            }
+        )
+        return {
+            "tests": tests,
+            "decision": AutoreviewDecision(
+                status="blocked",
+                label="Cannot be auto-approved",
+                reason="The earlier version of the article is in blocking categories.",
+            ),
+        }
+
+    tests.append(
+        {
+            "id": "blocking-categories",
+            "title": "Blocking categories",
+            "status": "passed",
+            "message": "The previous version is not in blocking categories.",
+        }
+    )
+
+    return {
+        "tests": tests,
+        "decision": AutoreviewDecision(
+            status="manual",
+            label="Requires human review",
+            reason="In dry-run mode the edit would not be approved automatically.",
+        ),
+    }
+
+
+def _normalize_to_lookup(values: Iterable[str] | None) -> dict[str, str]:
+    lookup: dict[str, str] = {}
+    if not values:
+        return lookup
+    for value in values:
+        if not value:
+            continue
+        normalized = str(value).casefold()
+        if normalized:
+            lookup[normalized] = str(value)
+    return lookup
+
+
+def _is_bot_user(revision: PendingRevision, profile: EditorProfile | None) -> bool:
+    if profile and profile.is_bot:
+        return True
+    superset = revision.superset_data or {}
+    if superset.get("rc_bot"):
+        return True
+    groups = superset.get("user_groups") or []
+    for group in groups:
+        if isinstance(group, str) and group.casefold() == "bot":
+            return True
+    return False
+
+
+def _matched_user_groups(
+    revision: PendingRevision,
+    profile: EditorProfile | None,
+    *,
+    allowed_groups: dict[str, str],
+) -> set[str]:
+    if not allowed_groups:
+        return set()
+
+    groups: list[str] = []
+    superset = revision.superset_data or {}
+    superset_groups = superset.get("user_groups") or []
+    if isinstance(superset_groups, list):
+        groups.extend(str(group) for group in superset_groups if group)
+    if profile and profile.usergroups:
+        groups.extend(str(group) for group in profile.usergroups if group)
+
+    matched: set[str] = set()
+    for group in groups:
+        normalized = group.casefold()
+        if normalized in allowed_groups:
+            matched.add(allowed_groups[normalized])
+    return matched
+
+
+def _blocking_category_hits(
+    revision: PendingRevision, blocking_lookup: dict[str, str]
+) -> set[str]:
+    if not blocking_lookup:
+        return set()
+
+    categories = list(revision.categories or [])
+    superset = revision.superset_data or {}
+    superset_categories = superset.get("page_categories") or []
+    if isinstance(superset_categories, list):
+        categories.extend(str(category) for category in superset_categories if category)
+
+    matched: set[str] = set()
+    for category in categories:
+        normalized = str(category).casefold()
+        if normalized in blocking_lookup:
+            matched.add(blocking_lookup[normalized])
+    return matched
+

--- a/app/reviews/urls.py
+++ b/app/reviews/urls.py
@@ -12,6 +12,11 @@ urlpatterns = [
         views.api_page_revisions,
         name="api_page_revisions",
     ),
+    path(
+        "api/wikis/<int:pk>/pages/<int:pageid>/autoreview/",
+        views.api_autoreview,
+        name="api_autoreview",
+    ),
     path("api/wikis/<int:pk>/clear/", views.api_clear_cache, name="api_clear_cache"),
     path("api/wikis/<int:pk>/configuration/", views.api_configuration, name="api_configuration"),
 ]

--- a/app/templates/reviews/index.html
+++ b/app/templates/reviews/index.html
@@ -114,6 +114,16 @@
                 </p>
               </header>
               <div class="card-content">
+                <div class="is-flex is-justify-content-flex-end mb-3">
+                  <button
+                    class="button is-primary is-light"
+                    :class="{ 'is-loading': isAutoreviewRunning(page) }"
+                    @click="runAutoreview(page)"
+                    :disabled="isAutoreviewRunning(page)"
+                  >
+                    Autoreview edits
+                  </button>
+                </div>
                 <div class="table-container">
                   <table class="table is-fullwidth is-striped">
                     <thead>
@@ -125,43 +135,60 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr v-for="revision in page.revisions" :key="revision.revid">
-                        <td>
-                          <a
-                            v-if="buildRevisionDiffUrl(page, revision)"
-                            :href="buildRevisionDiffUrl(page, revision)"
-                            class="has-text-link"
-                            target="_blank"
-                            rel="noreferrer noopener"
-                          >
-                            {{ formatDate(revision.timestamp) }}
-                          </a>
-                          <span v-else>{{ formatDate(revision.timestamp) }}</span>
-                        </td>
-                        <td>
-                          <template v-if="buildUserContributionsUrl(revision)">
+                      <template v-for="revision in page.revisions" :key="revision.revid">
+                        <tr>
+                          <td>
                             <a
-                              :href="buildUserContributionsUrl(revision)"
+                              v-if="buildRevisionDiffUrl(page, revision)"
+                              :href="buildRevisionDiffUrl(page, revision)"
                               class="has-text-link"
                               target="_blank"
                               rel="noreferrer noopener"
                             >
-                              {{ revision.user_name }}
+                              {{ formatDate(revision.timestamp) }}
                             </a>
-                          </template>
-                          <template v-else>
-                            {{ revision.user_name || 'Unknown' }}
-                          </template>
-                          <span class="tag is-danger is-light" v-if="revision.editor_profile.is_blocked">Blocked</span>
-                          <span class="tag is-info is-light" v-if="revision.editor_profile.is_bot">Bot</span>
-                          <span class="tag is-success is-light" v-if="revision.editor_profile.is_autopatrolled">Autopatrolled</span>
-                          <span class="tag is-success is-light" v-if="revision.editor_profile.is_autoreviewed">Autoreviewed</span>
-                        </td>
-                        <td>{{ revision.comment }}</td>
-                        <td>
-                          <span class="tag" v-for="tag in revision.change_tags" :key="tag">{{ tag }}</span>
-                        </td>
-                      </tr>
+                            <span v-else>{{ formatDate(revision.timestamp) }}</span>
+                          </td>
+                          <td>
+                            <template v-if="buildUserContributionsUrl(revision)">
+                              <a
+                                :href="buildUserContributionsUrl(revision)"
+                                class="has-text-link"
+                                target="_blank"
+                                rel="noreferrer noopener"
+                              >
+                                {{ revision.user_name }}
+                              </a>
+                            </template>
+                            <template v-else>
+                              {{ revision.user_name || 'Unknown' }}
+                            </template>
+                            <span class="tag is-danger is-light" v-if="revision.editor_profile.is_blocked">Blocked</span>
+                            <span class="tag is-info is-light" v-if="revision.editor_profile.is_bot">Bot</span>
+                            <span class="tag is-success is-light" v-if="revision.editor_profile.is_autopatrolled">Autopatrolled</span>
+                            <span class="tag is-success is-light" v-if="revision.editor_profile.is_autoreviewed">Autoreviewed</span>
+                          </td>
+                          <td>{{ revision.comment }}</td>
+                          <td>
+                            <span class="tag" v-for="tag in revision.change_tags" :key="tag">{{ tag }}</span>
+                          </td>
+                        </tr>
+                        <tr v-if="getRevisionReview(page, revision)">
+                          <td colspan="4" class="has-background-light">
+                            <div class="content mb-0">
+                              <p class="has-text-weight-semibold">Autoreview test results</p>
+                              <ul class="mb-2">
+                                <li v-for="test in getRevisionReview(page, revision).tests" :key="test.id" class="mb-1">
+                                  <span class="tag" :class="statusTagClass(test.status)">{{ formatTestStatus(test.status) }}</span>
+                                  <span class="ml-2 has-text-weight-semibold">{{ test.title }}</span>
+                                  <span class="ml-2">{{ test.message }}</span>
+                                </li>
+                              </ul>
+                              <p class="has-text-weight-semibold">{{ formatDecision(getRevisionReview(page, revision).decision) }}</p>
+                            </div>
+                          </td>
+                        </tr>
+                      </template>
                     </tbody>
                   </table>
                 </div>


### PR DESCRIPTION
## Summary
- add an autoreview service and API endpoint to evaluate pending revisions against bot, group and category rules in dry-run mode
- expose an “Autoreview edits” action in the Vue UI to run the checks per page and display the executed test results inline
- exercise the new endpoint with Django view tests covering approval, blocking, manual review, and ordering scenarios
- translate autoreview user-facing messages to English

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df5b393408832ebb47df1f06deebc0