### PR TITLE
Update autoreview status display to reflect rule outcome severity

### DIFF
--- a/app/reviews/autoreview.py
+++ b/app/reviews/autoreview.py
@@ -74,7 +74,7 @@ def _evaluate_revision(
             {
                 "id": "bot-user",
                 "title": "Bot user",
-                "status": "passed",
+                "status": "ok",
                 "message": "The edit could be auto-approved because the user is a bot.",
             }
         )
@@ -91,7 +91,7 @@ def _evaluate_revision(
         {
             "id": "bot-user",
             "title": "Bot user",
-            "status": "failed",
+            "status": "not_ok",
             "message": "The user is not marked as a bot.",
         }
     )
@@ -106,7 +106,7 @@ def _evaluate_revision(
                 {
                     "id": "auto-approved-group",
                     "title": "Auto-approved groups",
-                    "status": "passed",
+                    "status": "ok",
                     "message": "The user belongs to groups: {}.".format(
                         ", ".join(sorted(matched_groups))
                     ),
@@ -125,7 +125,7 @@ def _evaluate_revision(
             {
                 "id": "auto-approved-group",
                 "title": "Auto-approved groups",
-                "status": "failed",
+                "status": "not_ok",
                 "message": "The user does not belong to auto-approved groups.",
             }
         )
@@ -141,7 +141,7 @@ def _evaluate_revision(
                 {
                     "id": "auto-approved-group",
                     "title": "Auto-approved groups",
-                    "status": "passed",
+                    "status": "ok",
                     "message": "The user has default auto-approval rights: {}.".format(
                         ", ".join(default_rights)
                     ),
@@ -160,7 +160,7 @@ def _evaluate_revision(
             {
                 "id": "auto-approved-group",
                 "title": "Auto-approved groups",
-                "status": "failed",
+                "status": "not_ok",
                 "message": "The user does not have default auto-approval rights.",
             }
         )
@@ -172,7 +172,7 @@ def _evaluate_revision(
             {
                 "id": "blocking-categories",
                 "title": "Blocking categories",
-                "status": "failed",
+                "status": "fail",
                 "message": "The previous version belongs to blocking categories: {}.".format(
                     ", ".join(sorted(blocking_hits))
                 ),
@@ -191,7 +191,7 @@ def _evaluate_revision(
         {
             "id": "blocking-categories",
             "title": "Blocking categories",
-            "status": "passed",
+            "status": "not_ok",
             "message": "The previous version is not in blocking categories.",
         }
     )

--- a/app/reviews/tests/test_views.py
+++ b/app/reviews/tests/test_views.py
@@ -183,7 +183,7 @@ class ViewTests(TestCase):
         result = data["results"][0]
         self.assertEqual(result["decision"]["status"], "approve")
         self.assertEqual(len(result["tests"]), 1)
-        self.assertEqual(result["tests"][0]["status"], "passed")
+        self.assertEqual(result["tests"][0]["status"], "ok")
         self.assertEqual(result["tests"][0]["id"], "bot-user")
 
     def test_api_autoreview_allows_configured_user_groups(self):
@@ -220,7 +220,7 @@ class ViewTests(TestCase):
         result = response.json()["results"][0]
         self.assertEqual(result["decision"]["status"], "approve")
         self.assertEqual(len(result["tests"]), 2)
-        self.assertEqual(result["tests"][1]["status"], "passed")
+        self.assertEqual(result["tests"][1]["status"], "ok")
         self.assertEqual(result["tests"][1]["id"], "auto-approved-group")
 
     def test_api_autoreview_defaults_to_profile_rights(self):
@@ -259,7 +259,7 @@ class ViewTests(TestCase):
         result = response.json()["results"][0]
         self.assertEqual(result["decision"]["status"], "approve")
         self.assertEqual(len(result["tests"]), 2)
-        self.assertEqual(result["tests"][1]["status"], "passed")
+        self.assertEqual(result["tests"][1]["status"], "ok")
         self.assertIn("Autopatrolled", result["tests"][1]["message"])
 
     def test_api_autoreview_blocks_on_blocking_categories(self):
@@ -296,7 +296,7 @@ class ViewTests(TestCase):
         result = response.json()["results"][0]
         self.assertEqual(result["decision"]["status"], "blocked")
         self.assertEqual(len(result["tests"]), 3)
-        self.assertEqual(result["tests"][2]["status"], "failed")
+        self.assertEqual(result["tests"][2]["status"], "fail")
         self.assertEqual(result["tests"][2]["id"], "blocking-categories")
 
     def test_api_autoreview_requires_manual_review_when_no_rules_apply(self):
@@ -329,7 +329,7 @@ class ViewTests(TestCase):
         result = response.json()["results"][0]
         self.assertEqual(result["decision"]["status"], "manual")
         self.assertEqual(len(result["tests"]), 3)
-        self.assertEqual(result["tests"][2]["status"], "passed")
+        self.assertEqual(result["tests"][2]["status"], "not_ok")
 
     def test_api_autoreview_orders_revisions_from_oldest_to_newest(self):
         page = PendingPage.objects.create(

--- a/app/static/reviews/app.js
+++ b/app/static/reviews/app.js
@@ -424,30 +424,27 @@ createApp({
     }
 
     function formatTestStatus(status) {
-      if (status === "passed") {
-        return "Hyväksytty";
+      if (status === "ok") {
+        return "OK";
       }
-      if (status === "failed") {
-        return "Hylätty";
+      if (status === "fail") {
+        return "FAIL";
       }
-      if (status === "blocked") {
-        return "Estetty";
-      }
-      if (status === "skipped") {
-        return "Ohitettu";
+      if (status === "not_ok") {
+        return "NOT OK";
       }
       return status || "";
     }
 
     function statusTagClass(status) {
-      if (status === "passed") {
+      if (status === "ok") {
         return "is-success";
       }
-      if (status === "failed" || status === "blocked") {
+      if (status === "fail") {
         return "is-danger";
       }
-      if (status === "skipped") {
-        return "is-light";
+      if (status === "not_ok") {
+        return "is-warning";
       }
       return "is-light";
     }


### PR DESCRIPTION
## Summary
- categorize autoreview rule results so passing rules that end processing return OK, blocking rules return FAIL, and intermediate checks report NOT OK
- update the Vue frontend to show the new OK/FAIL/NOT OK labels with green, red, and yellow tag colors
- align autoreview API tests with the revised rule statuses

## Testing
- python app/manage.py test reviews

------
https://chatgpt.com/codex/tasks/task_e_68df73c0242c832ebf57336e055375e7