### PR TITLE
Mark non-blocking categories as OK

### DIFF
--- a/app/reviews/autoreview.py
+++ b/app/reviews/autoreview.py
@@ -191,7 +191,7 @@ def _evaluate_revision(
         {
             "id": "blocking-categories",
             "title": "Blocking categories",
-            "status": "not_ok",
+            "status": "ok",
             "message": "The previous version is not in blocking categories.",
         }
     )

--- a/app/reviews/tests/test_views.py
+++ b/app/reviews/tests/test_views.py
@@ -329,7 +329,7 @@ class ViewTests(TestCase):
         result = response.json()["results"][0]
         self.assertEqual(result["decision"]["status"], "manual")
         self.assertEqual(len(result["tests"]), 3)
-        self.assertEqual(result["tests"][2]["status"], "not_ok")
+        self.assertEqual(result["tests"][2]["status"], "ok")
 
     def test_api_autoreview_orders_revisions_from_oldest_to_newest(self):
         page = PendingPage.objects.create(


### PR DESCRIPTION
## Summary
- mark the blocking categories test as OK when no blocking categories are present
- update the autoreview view tests to expect the OK status

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68df75f08ee8832e85e7c957e28dd7a2