### PR TITLE
Update neutral label for inconclusive autoreview tests

### DIFF
--- a/app/static/reviews/app.js
+++ b/app/static/reviews/app.js
@@ -431,7 +431,7 @@ createApp({
         return "FAIL";
       }
       if (status === "not_ok") {
-        return "NOT OK";
+        return "Neutral";
       }
       return status || "";
     }


### PR DESCRIPTION
## Summary
- adjust the client-side formatter to display "Neutral" for not_ok autoreview test results

## Testing
- pytest *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68df78bd4ff0832e9d544415903e356d