### PR TITLE
Include reviewer, sysop, and editor in default auto-review groups

### DIFF
--- a/app/reviews/tests/test_services.py
+++ b/app/reviews/tests/test_services.py
@@ -177,6 +177,18 @@ class WikiClientTests(TestCase):
         self.assertTrue(profile.is_autoreviewed)
         self.assertFalse(profile.is_autopatrolled)
 
+    def test_ensure_editor_profile_marks_additional_autoreview_groups(self):
+        client = WikiClient(self.wiki)
+        profile = client.ensure_editor_profile(
+            "ReviewUser",
+            superset_data={"user_groups": ["Reviewer", "Sysop", "Editor"]},
+        )
+
+        self.assertEqual(profile.usergroups, ["Editor", "Reviewer", "Sysop"])
+        self.assertTrue(profile.is_autoreviewed)
+        self.assertFalse(profile.is_autopatrolled)
+        self.assertFalse(profile.is_bot)
+
 
 class RefreshWorkflowTests(TestCase):
     @mock.patch("reviews.services.SupersetQuery")


### PR DESCRIPTION
## Summary
- treat the reviewer, sysop, and editor groups as default auto-approval roles when hydrating editor profiles
- cover the new defaults with service- and view-layer tests

## Testing
- python app/manage.py test reviews

------
https://chatgpt.com/codex/tasks/task_e_68df9c26cc10832e9fa739a9489cb345