### PR TITLE
Add bulk autoreview button to pending pages list

### DIFF
--- a/app/static/reviews/app.js
+++ b/app/static/reviews/app.js
@@ -146,6 +146,7 @@ createApp({
       configurationOpen: loadConfigurationOpen(),
       reviewResults: {},
       runningReviews: {},
+      runningBulkReview: false,
     });
 
     const forms = reactive({
@@ -405,6 +406,31 @@ createApp({
       }
     }
 
+    async function runAutoreviewAllVisible() {
+      if (!state.selectedWikiId || state.runningBulkReview) {
+        return;
+      }
+      const pages = visiblePages.value || [];
+      if (!pages.length) {
+        return;
+      }
+      const wikiId = state.selectedWikiId;
+      state.runningBulkReview = true;
+      try {
+        for (const page of pages) {
+          if (!page) {
+            continue;
+          }
+          if (state.selectedWikiId !== wikiId) {
+            break;
+          }
+          await runAutoreview(page);
+        }
+      } finally {
+        state.runningBulkReview = false;
+      }
+    }
+
     function getRevisionReview(page, revision) {
       if (!page || !revision) {
         return null;
@@ -515,6 +541,7 @@ createApp({
       buildRevisionDiffUrl,
       buildUserContributionsUrl,
       runAutoreview,
+      runAutoreviewAllVisible,
       getRevisionReview,
       isAutoreviewRunning,
       formatTestStatus,

--- a/app/templates/reviews/index.html
+++ b/app/templates/reviews/index.html
@@ -92,6 +92,16 @@
             <p class="help" v-if="hasMorePages">
               Showing the first {{ pageDisplayLimit }} of {{ state.pages.length }} pending pages.
             </p>
+            <div class="buttons mt-3">
+              <button
+                class="button is-primary"
+                @click="runAutoreviewAllVisible"
+                :class="{ 'is-loading': state.runningBulkReview }"
+                :disabled="!visiblePages.length || state.runningBulkReview"
+              >
+                Autoreview all listed pages
+              </button>
+            </div>
             <article v-for="page in visiblePages" :key="page.pageid" class="card mb-5">
               <header class="card-header">
                 <p class="card-header-title is-size-5 is-flex is-align-items-center">
@@ -119,7 +129,7 @@
                     class="button is-primary is-light"
                     :class="{ 'is-loading': isAutoreviewRunning(page) }"
                     @click="runAutoreview(page)"
-                    :disabled="isAutoreviewRunning(page)"
+                    :disabled="isAutoreviewRunning(page) || state.runningBulkReview"
                   >
                     Autoreview edits
                   </button>


### PR DESCRIPTION
## Summary
- add a bulk "Autoreview all listed pages" action to the pending pages view and disable individual buttons while it runs
- implement frontend logic to sequentially trigger autoreview for each visible page and prevent concurrent runs

## Testing
- pytest *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa61785c4832e9233224585750f3d